### PR TITLE
LPS-69935 with test

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.TableNameOrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.impl.UserImpl;
@@ -675,7 +676,8 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 				socialRelationTypeComparator.equals(StringPool.EQUAL) ?
 					StringPool.EQUAL : StringPool.NOT_EQUAL);
 
-			sql = CustomSQLUtil.replaceOrderBy(sql, obc);
+			sql = CustomSQLUtil.replaceOrderBy(
+				sql, new TableNameOrderByComparator<>(obc, "User_"));
 
 			SQLQuery q = session.createSynchronizedSQLQuery(sql);
 

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -676,8 +676,10 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 				socialRelationTypeComparator.equals(StringPool.EQUAL) ?
 					StringPool.EQUAL : StringPool.NOT_EQUAL);
 
-			sql = CustomSQLUtil.replaceOrderBy(
-				sql, new TableNameOrderByComparator<>(obc, "User_"));
+			if (obc != null) {
+				sql = CustomSQLUtil.replaceOrderBy(
+					sql, new TableNameOrderByComparator<>(obc, "User_"));
+			}
 
 			SQLQuery q = session.createSynchronizedSQLQuery(sql);
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/UserFinderTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/UserFinderTest.java
@@ -32,9 +32,12 @@ import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.TransactionalTestRule;
+import com.liferay.social.kernel.model.SocialRelationConstants;
+import com.liferay.social.kernel.service.SocialRelationLocalServiceUtil;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -73,6 +76,12 @@ public class UserFinderTest {
 		OrganizationLocalServiceUtil.addUserOrganization(
 			_organizationUser.getUserId(), _organization);
 
+		_socialUser = UserTestUtil.addUser();
+
+		SocialRelationLocalServiceUtil.addRelation(
+			_groupUser.getUserId(), _socialUser.getUserId(),
+			SocialRelationConstants.TYPE_BI_CONNECTION);
+
 		_userGroup = UserGroupTestUtil.addUserGroup();
 		_userGroupUser = UserTestUtil.addUser();
 
@@ -89,6 +98,7 @@ public class UserFinderTest {
 
 		OrganizationLocalServiceUtil.deleteOrganization(_organization);
 
+		UserLocalServiceUtil.deleteUser(_socialUser);
 		UserLocalServiceUtil.deleteUser(_userGroupUser);
 
 		UserGroupLocalServiceUtil.deleteUserGroup(_userGroup);
@@ -317,10 +327,22 @@ public class UserFinderTest {
 		Assert.assertEquals(expectedUsers.size() + 2, users.size());
 	}
 
+	@Test
+	public void testFindBySocialUsers() throws Exception {
+		List<User> socialUsers = UserFinderUtil.findBySocialUsers(
+			TestPropsValues.getCompanyId(), _groupUser.getUserId(),
+			SocialRelationConstants.TYPE_BI_CONNECTION, StringPool.EQUAL,
+			WorkflowConstants.STATUS_ANY, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			null);
+
+		Assert.assertEquals(1, socialUsers.size());
+	}
+
 	private static Group _group;
 	private static User _groupUser;
 	private static Organization _organization;
 	private static User _organizationUser;
+	private static User _socialUser;
 	private static UserGroup _userGroup;
 	private static User _userGroupUser;
 


### PR DESCRIPTION
Hi Pisti,

I added a test to UserFinderTest based on SocialRelationLocalServiceTest, but for some reason, it returns 0 when it should return 1 in testFindBySocialUsers.

Can you please look into this? We should have a test for the issue.

Thanks!
Tibi

This is what I'm using to run the tests on PostgreSQL locally:
**portal-test-ext.properties**
```properties
jdbc.default.driverClassName=org.postgresql.Driver
jdbc.default.url=jdbc:postgresql://localhost:5432/lportal-master
jdbc.default.username=postgres
jdbc.default.password=postgres
liferay.home=/home/tibusz/liferay/bundles/master
module.framework.base.dir=/home/tibusz/liferay/bundles/master/osgi
```

FYI: CI runs the tests on all DBs for each pull.